### PR TITLE
Fully strip binaries

### DIFF
--- a/binaryen.proj
+++ b/binaryen.proj
@@ -88,12 +88,13 @@
         <ItemGroup>
           <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" />
         </ItemGroup>
-        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
+        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
         <Exec IgnoreStandardErrorWarningFormat="true"
           Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
-        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" />
+        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
         <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="codesign -f -s - %(BinaryenToStrip.FullPath)" />
+          Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
+          Condition="'$(BuildOS)' == 'OSX'" />
       </When>
     </Choose>
 

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ClangVersion Condition="'$(ClangVersion)' == ''">clang</ClangVersion>
     <ClangPlusVersion Condition="'$(ClangPlusVersion)' == ''">clang++</ClangPlusVersion>
+    <ObjCopy Condition="'$(ClangVersion)' == 'clang-9'">/usr/lib/llvm-9/bin/llvm-objcopy</ObjCopy>
+    <ObjCopy Condition="'$(ClangVersion)' != 'clang-9'">llvm-objcopy</ObjCopy>
     <Sysroot Condition="'$(ROOTFS_DIR)' == ''">/</Sysroot>
     <Sysroot Condition="'$(ROOTFS_DIR)' != ''">$(ROOTFS_DIR)</Sysroot>
     <CMakeGenerator Condition="$(CMakeGenerator) == '' and '$(BuildOS)' != 'Windows_NT'">Unix Makefiles</CMakeGenerator>
@@ -71,6 +73,26 @@
     <Exec WorkingDirectory="$(BinaryenBuildDir)"
       Command="$(_BuildCommand) install"
       IgnoreStandardErrorWarningFormat="true" />
+    <ItemGroup>
+      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" />
+    </ItemGroup>
+    <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'OSX'" />
+    <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'OSX'" />
+    <Message Importance="High" Text="** Running $(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="$(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'Linux'" />
+    <Message Importance="High" Text="** Running $(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="$(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'Linux'" />
+
   </Target>
 
   <Target Name="WriteVersionFile" AfterTargets="ReallyBuild">

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -74,7 +74,8 @@
       Command="$(_BuildCommand) install"
       IgnoreStandardErrorWarningFormat="true" />
     <ItemGroup>
-      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" />
+      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dbg" Condition="'$(BuildOS)' == 'Linux'" />
+      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" Condition="'$(BuildOS)' == 'OSX'" />
     </ItemGroup>
     <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
     <Exec IgnoreStandardErrorWarningFormat="true"

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -72,26 +72,31 @@
     <Exec WorkingDirectory="$(BinaryenBuildDir)"
       Command="$(_BuildCommand) install"
       IgnoreStandardErrorWarningFormat="true" />
-    <ItemGroup>
-      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dbg" Condition="'$(BuildOS)' == 'Linux'" />
-      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" Condition="'$(BuildOS)' == 'OSX'" />
-    </ItemGroup>
-    <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
-    <Exec IgnoreStandardErrorWarningFormat="true"
-      Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)"
-      Condition="'$(BuildOS)' == 'OSX'" />
-    <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
-    <Exec IgnoreStandardErrorWarningFormat="true"
-      Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
-      Condition="'$(BuildOS)' == 'OSX'" />
-    <Message Importance="High" Text="** Running $(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
-    <Exec IgnoreStandardErrorWarningFormat="true"
-      Command="$(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)"
-      Condition="'$(BuildOS)' == 'Linux'" />
-    <Message Importance="High" Text="** Running $(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
-    <Exec IgnoreStandardErrorWarningFormat="true"
-      Command="$(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)"
-      Condition="'$(BuildOS)' == 'Linux'" />
+    <Choose>
+      <When Condition="'$(BuildOS)' == 'Linux'">
+        <ItemGroup>
+          <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dbg" />
+        </ItemGroup>
+        <Message Importance="High" Text="** Running $(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" />
+        <Exec IgnoreStandardErrorWarningFormat="true"
+          Command="$(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" />
+        <Message Importance="High" Text="** Running $(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" />
+        <Exec IgnoreStandardErrorWarningFormat="true"
+          Command="$(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" />
+      </When>
+      <When Condition="'$(BuildOS)' == 'OSX'">
+        <ItemGroup>
+          <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" />
+        </ItemGroup>
+        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+        <Exec IgnoreStandardErrorWarningFormat="true"
+          Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
+        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+        <Exec IgnoreStandardErrorWarningFormat="true"
+          Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
+          Condition="'$(BuildOS)' == 'OSX'" />
+      </When>
+    </Choose>
 
   </Target>
 

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -72,31 +72,26 @@
     <Exec WorkingDirectory="$(BinaryenBuildDir)"
       Command="$(_BuildCommand) install"
       IgnoreStandardErrorWarningFormat="true" />
-    <Choose>
-      <When Condition="'$(BuildOS)' == 'Linux'">
-        <ItemGroup>
-          <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dbg" />
-        </ItemGroup>
-        <Message Importance="High" Text="** Running $(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" />
-        <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="$(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" />
-        <Message Importance="High" Text="** Running $(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" />
-        <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="$(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" />
-      </When>
-      <When Condition="'$(BuildOS)' == 'OSX'">
-        <ItemGroup>
-          <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" />
-        </ItemGroup>
-        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
-        <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
-        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
-        <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
-          Condition="'$(BuildOS)' == 'OSX'" />
-      </When>
-    </Choose>
+    <ItemGroup>
+      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dbg" Condition="'$(BuildOS)' == 'Linux'" />
+      <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" Condition="'$(BuildOS)' == 'OSX'" />
+    </ItemGroup>
+    <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'OSX'" />
+    <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'OSX'" />
+    <Message Importance="High" Text="** Running $(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="$(ObjCopy) --strip-all %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'Linux'" />
+    <Message Importance="High" Text="** Running $(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'Linux'" />
+    <Exec IgnoreStandardErrorWarningFormat="true"
+      Command="$(ObjCopy) --add-gnu-debuglink=%(BinaryenToStrip.FullPath).dbg %(BinaryenToStrip.FullPath)"
+      Condition="'$(BuildOS)' == 'Linux'" />
 
   </Target>
 

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <ClangVersion Condition="'$(ClangVersion)' == ''">clang</ClangVersion>
     <ClangPlusVersion Condition="'$(ClangPlusVersion)' == ''">clang++</ClangPlusVersion>
-    <ObjCopy Condition="'$(ClangVersion)' == 'clang-9'">/usr/lib/llvm-9/bin/llvm-objcopy</ObjCopy>
-    <ObjCopy Condition="'$(ClangVersion)' != 'clang-9'">llvm-objcopy</ObjCopy>
+    <ObjCopy>$(ObjCopyPrefix)llvm-objcopy</ObjCopy>
     <Sysroot Condition="'$(ROOTFS_DIR)' == ''">/</Sysroot>
     <Sysroot Condition="'$(ROOTFS_DIR)' != ''">$(ROOTFS_DIR)</Sysroot>
     <CMakeGenerator Condition="$(CMakeGenerator) == '' and '$(BuildOS)' != 'Windows_NT'">Unix Makefiles</CMakeGenerator>

--- a/binaryen.proj
+++ b/binaryen.proj
@@ -88,13 +88,12 @@
         <ItemGroup>
           <BinaryenToStrip Include="$(BinaryenInstallDir)\bin\*" Exclude="$(BinaryenInstallDir)\bin\*.dwarf" />
         </ItemGroup>
-        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+        <Message Importance="High" Text="** Running strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
         <Exec IgnoreStandardErrorWarningFormat="true"
           Command="strip -no_code_signature_warning -S %(BinaryenToStrip.FullPath)" />
-        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" Condition="'$(BuildOS)' == 'OSX'" />
+        <Message Importance="High" Text="** Running codesign -f -s - %(BinaryenToStrip.FullPath)" />
         <Exec IgnoreStandardErrorWarningFormat="true"
-          Command="codesign -f -s - %(BinaryenToStrip.FullPath)"
-          Condition="'$(BuildOS)' == 'OSX'" />
+          Command="codesign -f -s - %(BinaryenToStrip.FullPath)" />
       </When>
     </Choose>
 

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -41,6 +41,7 @@ stages:
               rootfs: /crossrootfs/x64
               ClangTargetArg: 
               ClangVersionArg: /p:ClangVersion=clang-9 /p:ClangPlusVersion=clang++-9
+              ObjCopyPrefixArg: /p:ObjCopyPrefix=/usr/lib/llvm-9/bin/
               archflag: --arch x64
             arm64:
               assetManifestOS: linux
@@ -49,6 +50,7 @@ stages:
               rootfs: /crossrootfs/arm64
               ClangTargetArg: /p:ClangTarget=aarch64-linux-gnu
               ClangVersionArg: /p:ClangVersion=clang-9 /p:ClangPlusVersion=clang++-9
+              ObjCopyPrefixArg: /p:ObjCopyPrefix=/usr/lib/llvm-9/bin/
               archflag: --arch arm64
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
@@ -66,7 +68,7 @@ stages:
           displayName: 'Clean up working directory'
 
         - bash: |
-            ./build.sh --ci --restore --build --pack $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs) $(ClangTargetArg) $(ClangVersionArg) /p:RestoreUsingNuGetTargets=false
+            ./build.sh --ci --restore --build --pack $(archflag) --configuration $(_BuildConfig) $(_InternalBuildArgs) $(ClangTargetArg) $(ClangVersionArg) $(ObjCopyPrefixArg) /p:RestoreUsingNuGetTargets=false
           displayName: 'Build and package'
           env:
             ROOTFS_DIR: $(rootfs)


### PR DESCRIPTION
The build system is splitting off and packaging debug symbols, but isn't fully stripping the binaries (so they show as "not stripped" to `file`)