### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
-      <PublishingVersion>3</PublishingVersion>
+      <PublishingVersion>4</PublishingVersion>
    </PropertyGroup>
 </Project>

--- a/eng/azure-pipelines-public.yml
+++ b/eng/azure-pipelines-public.yml
@@ -23,7 +23,6 @@ stages:
     parameters:
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       jobs:
 
       ############ LINUX BUILD ############

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -59,11 +59,12 @@ extends:
         parameters:
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           jobs:
 
           ############ LINUX X64 BUILD ############
           - job: Build_Linux_x64
+            enablePublishing: true
             displayName: Linux_x64
             timeoutInMinutes: 360
             variables:
@@ -96,6 +97,7 @@ extends:
 
           ############ LINUX ARM64 BUILD ############
           - job: Build_Linux_arm64
+            enablePublishing: true
             displayName: Linux_arm64
             timeoutInMinutes: 360
             variables:
@@ -128,6 +130,7 @@ extends:
 
           ############ LINUX MUSL X64 BUILD ############
           - job: Build_Linux_musl_x64
+            enablePublishing: true
             displayName: Linux_musl_x64
             timeoutInMinutes: 360
             variables:
@@ -160,6 +163,7 @@ extends:
 
           ############ LINUX MUSL ARM64 BUILD ############
           - job: Build_Linux_musl_arm64
+            enablePublishing: true
             displayName: Linux_musl_arm64
             timeoutInMinutes: 360
             variables:
@@ -192,6 +196,7 @@ extends:
 
           ############ MACOS X64 BUILD ############
           - job: Build_macOS_x64
+            enablePublishing: true
             displayName: macOS_x64
             timeoutInMinutes: 360
             variables:
@@ -218,6 +223,7 @@ extends:
 
           ############ MACOS ARM64 BUILD ############
           - job: Build_macOS_ARM64
+            enablePublishing: true
             displayName: macOS_arm64
             timeoutInMinutes: 360
             variables:
@@ -244,6 +250,7 @@ extends:
 
           ############ WINDOWS X64 BUILD ############
           - job: Build_Windows_x64
+            enablePublishing: true
             displayName: Windows_x64
             timeoutInMinutes: 120
             variables:
@@ -268,6 +275,7 @@ extends:
 
           ############ WINDOWS ARM64 BUILD ############
           - job: Build_Windows_arm64
+            enablePublishing: true
             displayName: Windows_arm64
             timeoutInMinutes: 120
             variables:
@@ -293,6 +301,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         enableSourceLinkValidation: false
         enableSigningValidation: false
         enableSymbolValidation: false

--- a/eng/common-variables.yml
+++ b/eng/common-variables.yml
@@ -32,6 +32,5 @@ variables:
     - group: DotNet-HelixApi-Access
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting PublishingVersion to 4
- switching pipeline jobs to V4 publishingVersion/enablePublishing
- removing legacy V3 publish toggles