### PR TITLE
Enable Control Flow Guard for Windows binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,11 @@ if(MSVC)
 
   add_link_flag("/STACK:8388608")
 
+  # Enable Control Flow Guard. The flag is needed both when compiling (to emit
+  # the guard checks) and when linking (to emit the guard address tables).
+  add_compile_flag("/guard:cf")
+  add_link_flag("/guard:cf")
+
 else() # MSVC
 
   add_compile_flag("-fno-omit-frame-pointer")


### PR DESCRIPTION
Adds `/guard:cf` to the MSVC compile and link flags so `wasm-opt.exe` and the other tools ship with Control Flow Guard enabled.

The flag is required both when compiling (to emit the guard checks) and when linking (to emit the guard address tables), so it goes through both `add_compile_flag` and `add_link_flag` -- the same idiom already used next to it for `/STACK:8388608`. `add_link_flag` covers `CMAKE_EXE_LINKER_FLAGS` and `CMAKE_SHARED_LINKER_FLAGS`.

Non-MSVC builds are unaffected (the change is inside the existing `if(MSVC)` block).

Note: `CMakeLists.txt` was edited directly rather than going through `eng/patches`, per offline discussion that the quilt patches are being reworked.

### Verification

Full local Windows x64 Release build via `eng\build.ps1`, before and after.

CMake picks up both flags:
```
-- Building with /guard:cf
-- Linking with /guard:cf
```

`dumpbin /loadconfig` on the produced binaries:

| | Guard Flags | CF function count |
|---|---|---|
| before | `00000100` | **0** -- empty table, CFG not enforced |
| after (`wasm-opt.exe`) | `10014500` | 13263 |

All 13 installed tools are covered (`wasm-opt`, `wasm-as`, `wasm-dis`, `wasm-merge`, `wasm-metadce`, `wasm-split`, `wasm-reduce`, `wasm-shell`, `wasm-ctor-eval`, `wasm2js`, `wasm-emscripten-finalize`, `wasm-fuzz-types`, `wasm-fuzz-lattices`).

Note the "CF instrumented" bit alone is not sufficient evidence -- it is present even without the flag, with an empty function table. The function count is what shows CFG is actually enforced.

Runtime behaviour is unchanged:
- `wasm-as` -> `wasm-opt -O3` -> `wasm-dis` round trip produces correct output.
- 12 fuzzer-generated modules (`wasm-opt -ttf`) optimized at `-O3` with `--fuzz-exec`: all 12 produce identical results before and after optimization. This exercises heavy virtual dispatch, which is the main CFG risk area for C++.
- `wasm-shell` spec assertions pass, and `wasm2js`, `wasm-metadce`, `wasm-split` all run clean.
