### PR TITLE
Pass CMake flags via the *_INIT variables to preserve platform defaults

### DIFF
--- a/binaryen.proj
+++ b/binaryen.proj
@@ -81,10 +81,15 @@
       <_BuildArgs Condition="'$(BuildOS)' == 'OSX'" Include="-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0" />
       <_BuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'x64'" Include="-DCMAKE_OSX_ARCHITECTURES=x86_64" />
       <_BuildArgs Condition="'$(BuildOS)' == 'OSX' and '$(TargetArchitecture)' == 'arm64'" Include="-DCMAKE_OSX_ARCHITECTURES=arm64" />
-      <_BuildArgs Include='-DCMAKE_C_FLAGS="$(_CrossCFlags)"' />
-      <_BuildArgs Include='-DCMAKE_CXX_FLAGS="$(_CrossCXXFlags)"' />
-      <_BuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS="$(_ExeLinkerFlags)"' />
-      <_BuildArgs Include='-DCMAKE_SHARED_LINKER_FLAGS="$(_SharedLinkerFlags)"' />
+      <!-- Use the *_INIT variables rather than setting CMAKE_<LANG>_FLAGS et al directly:
+           setting the cache variables suppresses the values the platform modules contribute,
+           which on MSVC silently dropped /DWIN32 /D_WINDOWS /GR /EHsc and /machine:<arch>.
+           The *_INIT variables are appended to by the platform modules, so both our flags
+           and the platform defaults (and $ENV{CXXFLAGS}/$ENV{LDFLAGS}) are preserved. -->
+      <_BuildArgs Include='-DCMAKE_C_FLAGS_INIT="$(_CrossCFlags)"' />
+      <_BuildArgs Include='-DCMAKE_CXX_FLAGS_INIT="$(_CrossCXXFlags)"' />
+      <_BuildArgs Include='-DCMAKE_EXE_LINKER_FLAGS_INIT="$(_ExeLinkerFlags)"' />
+      <_BuildArgs Include='-DCMAKE_SHARED_LINKER_FLAGS_INIT="$(_SharedLinkerFlags)"' />
       <_BuildArgs Include="-DBUILD_TESTS:BOOL=OFF" />
       <_BuildArgs Include="-DINSTALL_LIBS:BOOL=OFF" />
       <_BuildArgs Condition="'$(BuildOS)' == 'Linux'" Include="-DCMAKE_C_COMPILER=clang" />


### PR DESCRIPTION
`binaryen.proj` passed `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS` / `CMAKE_EXE_LINKER_FLAGS` / `CMAKE_SHARED_LINKER_FLAGS` directly on the cmake command line. Those are *cache* variables, and CMake only initializes them from `CMAKE_<LANG>_FLAGS_INIT` when they are not already in the cache -- so passing them with `-D` suppressed everything the platform modules contribute.

Those properties are only populated when cross-compiling on Linux/macOS. On Windows they are empty, so cmake received `-DCMAKE_CXX_FLAGS=""` and the MSVC defaults were silently dropped.

Actual compile line before this change -- no `/EHsc`, no `/GR`, no `/DWIN32 /D_WINDOWS`:
```
FLAGS = /MP /D_SILENCE_... /DBUILD_LLVM_DWARF /wd4146 ... /Zi /O2 -std:c++20 -MT
```
And the exe link line was missing `/machine:x64`.

**Losing `/EHsc` is the one that matters.** Binaryen relies on exceptions for error reporting (~251 `throw`/`catch` sites; `ParseException` drives all parse errors). Without `/EHsc` MSVC does not emit unwind code for automatic objects, so destructors are skipped while an exception propagates, and the compiler may assume functions are `noexcept`. The build was emitting **260 instances** of:
```
warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
```
Error paths still appeared to work, which is what made this easy to miss.

### The fix

Switch to the `*_INIT` variables. Platform modules `string(APPEND)` to those, so our flags and the platform defaults compose instead of one replacing the other.

This is deliberately preferred over conditionally skipping the `-D` args when empty. That alternative would work today only because Linux/macOS platform modules happen to contribute nothing to `*_FLAGS_INIT` -- if that ever changes (new CMake, new Apple platform module, Clang bump) the same bug would silently reappear on those platforms. The `*_INIT` form is correct regardless of what the platform contributes.

It also restores the `$ENV{CXXFLAGS}` / `$ENV{LDFLAGS}` contribution (`CMakeCXXInformation.cmake` does `set(CMAKE_CXX_FLAGS_INIT "$ENV{CXXFLAGS} ${CMAKE_CXX_FLAGS_INIT}")`), which the cache overwrite was discarding on **every** platform.

### Verification

Full local Windows x64 Release build, before and after.

Compile and link lines after:
```
FLAGS      = /DWIN32 /D_WINDOWS /GR /EHsc /MP ... -std:c++20 -MT
LINK_FLAGS = /machine:x64 /STACK:8388608 /debug /INCREMENTAL /subsystem:console
```

- C4530 warnings: **260 -> 0**. Build log shrank from 299 KB to 153 KB.
- Composition confirmed with a probe: `-DCMAKE_CXX_FLAGS_INIT="/DFOO_TEST"` yields `/DFOO_TEST /DWIN32 /D_WINDOWS /GR /EHsc`, and `-DCMAKE_EXE_LINKER_FLAGS_INIT="/DEBUG:FULL"` yields `/DEBUG:FULL /machine:x64` -- our value and the platform default both survive.
- `wasm-opt` works: 8 fuzzer-generated modules (`-ttf`) optimized at `-O3` with `--fuzz-exec` all produce identical results before and after optimization; malformed input still reports a clean parse error.

Note this changes Windows codegen (real unwind code is now emitted), which is why it is split out from #386 rather than folded in.

Ordering note: our flags now come *before* the platform defaults. That is fine for the current cross flags (`--target`, `--sysroot`, `-nostdinc++`, `-fuse-ld=lld`, `-L...`), which do not conflict with anything the platform modules add. Only x64 Windows was built locally; the Linux/macOS/arm64 legs rely on CI.
