### PR TITLE
[release/10.0] Enable Control Flow Guard for Windows binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,11 @@ if(MSVC)
 
   add_link_flag("/STACK:8388608")
 
+  # Enable Control Flow Guard. The flag is needed both when compiling (to emit
+  # the guard checks) and when linking (to emit the guard address tables).
+  add_compile_flag("/guard:cf")
+  add_link_flag("/guard:cf")
+
   if(RUN_STATIC_ANALYZER)
     add_definitions(/analyze)
   endif()


### PR DESCRIPTION
Port of #386 to `dotnet/release/10.0`.

Adds `/guard:cf` to the MSVC compile and link flags so `wasm-opt.exe` and the other tools ship with Control Flow Guard enabled.

The flag is required both when compiling (to emit the guard checks) and when linking (to emit the guard address tables), so it goes through both `add_compile_flag` and `add_link_flag` -- the same idiom already used next to it for `/STACK:8388608`. `add_link_flag` covers `CMAKE_EXE_LINKER_FLAGS` and `CMAKE_SHARED_LINKER_FLAGS`.

Non-MSVC builds are unaffected (the change is inside the existing `if(MSVC)` block).

This branch carries an older binaryen (version 117 vs 129 on `dotnet/main`) and its MSVC block differs, so the change was applied manually rather than cherry-picked. The inserted lines are identical; only the surrounding context differs.

Note: `CMakeLists.txt` was edited directly rather than going through `eng/patches`, per offline discussion that the quilt patches are being reworked.

### Verification

Full local Windows x64 Release build on this branch.

CMake picks up both flags:
```
-- Building with /guard:cf
-- Linking with /guard:cf
```

`dumpbin /loadconfig` confirms CFG is enforced on all 13 installed tools, e.g. `wasm-opt.exe` -> `Guard Flags 10014500`, 25770 CF functions. For comparison, a build without the flag yields `Guard Flags 00000100` with a CF function count of **0**, i.e. not enforced -- the "CF instrumented" bit alone is present either way, so the function count is what matters.

Runtime behaviour is unchanged:
- 8 fuzzer-generated modules (`wasm-opt -ttf`) optimized at `-O3` with `--fuzz-exec`: all 8 produce identical results before and after optimization. This exercises heavy virtual dispatch, the main CFG risk area for C++.
- `wasm-shell` spec assertions pass (`seen 120, expected 120`).

Only x64 was built locally; the arm64 leg relies on CI.
