### PR TITLE
Add GitHub-backed ADO CodeQL pipeline

### DIFF
--- a/eng/azure-pipelines-github-codeql.yml
+++ b/eng/azure-pipelines-github-codeql.yml
@@ -1,0 +1,78 @@
+# Create this pipeline in `dnceng/internal` against the GitHub repository
+# `dotnet/binaryen` so GitHub-attributed CodeQL snapshots stay separate from
+# the existing ADO-mirror pipeline in `eng/azure-pipelines.yml`.
+# After merge, create or update that ADO definition to point to this file and
+# queue one `dotnet/main` run to seed the initial GitHub-attributed snapshots.
+
+trigger:
+  batch: true
+  branches:
+    include:
+    - dotnet/main
+
+pr: none
+
+schedules:
+- cron: 0 0 * * 0
+  displayName: Weekly CodeQL refresh
+  branches:
+    include:
+    - dotnet/main
+  always: true
+
+variables:
+- template: /eng/common-variables.yml@self
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    sdl:
+      codeql:
+        compiled:
+          enabled: true
+        runSourceLanguagesInSourceAnalysis: true
+        sourceLanguages: javascript, python
+        binaryLanguages: cpp
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+    containers:
+      mariner2crossamd64:
+        image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
+    stages:
+    - stage: build
+      displayName: CodeQL
+      jobs:
+      - template: /eng/common/templates-official/jobs/jobs.yml@self
+        parameters:
+          jobs:
+
+          ############ LINUX BUILD ############
+          - job: Build_Linux_x64
+            displayName: Linux_x64
+            timeoutInMinutes: 360
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: build.azurelinux.3.amd64
+              os: linux
+            container: mariner2crossamd64
+            steps:
+            - script: |
+                git clean -ffdx
+                git reset --hard HEAD
+              displayName: Clean up working directory
+
+            - bash: |
+                ./build.sh --ci --restore --build --arch x64 --configuration $(_BuildConfig) $(_InternalBuildArgs) /p:RestoreUsingNuGetTargets=false
+              displayName: Build for CodeQL
+              env:
+                ROOTFS_DIR: /crossrootfs/x64


### PR DESCRIPTION
Summary
- add `eng/azure-pipelines-github-codeql.yml` for a GitHub-backed `dnceng/internal` CodeQL pipeline definition
- keep `eng/azure-pipelines.yml` unchanged so ADO attribution stays on `ado:dnceng/internal/dotnet-binaryen`
- replace the earlier GitHub Actions workflow approach because this repo is ADO/1ES-first
- target only the missing GitHub identity by running source analysis for `javascript` and `python`, and a real Linux x64 build for `cpp`

Evidence
- GitHub currently has no CodeQL databases for this repo. `gh api repos/dotnet/binaryen/code-scanning/codeql/databases` returned `[]`.
- Internal ADO mirror coverage already exists. On successful `dotnet-binaryen-official` build `3040049` for `refs/heads/dotnet/main`, CodeQL3000 created:
  - compiled `cpp` in job `Build_Linux_arm64` with `LanguageDetectorFilter = compiled`
  - interpreted `python` and `javascript` in job `SDLSources_SDLSources` with `LanguageDetectorFilter = interpreted`
- The latest mainline internal build `3041690` failed later in `NuGet Validation` due to infrastructure, not CodeQL configuration.

Validation
- `ruby -e 'require "yaml"; YAML.load_file("eng/azure-pipelines-github-codeql.yml")'`
- `git diff --check`
- `./build.sh --ci --restore --build --arch x64 --configuration Release /p:RestoreUsingNuGetTargets=false`

Post-merge
- create a new `dnceng/internal` ADO pipeline definition against `https://github.com/dotnet/binaryen` that points to `eng/azure-pipelines-github-codeql.yml`
- queue one `dotnet/main` run after that definition exists so the initial GitHub-attributed `cpp`, `javascript`, and `python` snapshots are produced
- keep the existing ADO mirror coverage on `eng/azure-pipelines.yml`, which already satisfies `ado:dnceng/internal/dotnet-binaryen`
